### PR TITLE
Support other languages in item indicator

### DIFF
--- a/LeagueBroadcast/Common/Data/Config/ComponentConfig.cs
+++ b/LeagueBroadcast/Common/Data/Config/ComponentConfig.cs
@@ -59,7 +59,8 @@ namespace LeagueBroadcast.Common.Data.Config
         {
             return new() {
                 DataDragon = new DataDragonConfig() {
-                    MinimumGoldCost = 2000
+                    MinimumGoldCost = 2000,
+					lang = "en_US"
                 },
                 PickBan = new PickBanConfig() {
                     IsActive = true,
@@ -180,6 +181,7 @@ namespace LeagueBroadcast.Common.Data.Config
     public class DataDragonConfig
     {
         public int MinimumGoldCost;
+		public string lang;
     }
 
     public class PickBanConfig

--- a/LeagueBroadcast/Common/Data/Provider/DataDragon.cs
+++ b/LeagueBroadcast/Common/Data/Provider/DataDragon.cs
@@ -127,7 +127,7 @@ namespace LeagueBroadcast.Common.Data.Provider
 
         private async void Init()
         {
-            Log.Info($"Champion: {version.Champion}, Item: {version.Item}, CDN: {version.CDN}");
+            Log.Info($"Champion: {version.Champion}, Item: {version.Item}, CDN: {version.CDN}, DDRAGONLANG: {ConfigController.Component.DataDragon.lang}");
 
             Champion.Champions = new List<Champion>(JsonConvert.DeserializeObject<dynamic>(await DataDragonUtils.GetAsync($"{version.CDN}/{version.Champion}/data/en_US/champion.json")).data.ToObject<Dictionary<string, Champion>>().Values);
             Log.Info($"Loaded {Champion.Champions.Count} champions");
@@ -135,7 +135,7 @@ namespace LeagueBroadcast.Common.Data.Provider
             SummonerSpell.SummonerSpells = new List<SummonerSpell>(JsonConvert.DeserializeObject<dynamic>(await DataDragonUtils.GetAsync($"{version.CDN}/{version.Item}/data/en_US/summoner.json")).data.ToObject<Dictionary<string, SummonerSpell>>().Values);
             Log.Info($"Loaded {SummonerSpell.SummonerSpells.Count} summoner spells");
 
-            List<KeyValuePair<int, ItemData>> rawItemData = new List<KeyValuePair<int, ItemData>>(JsonConvert.DeserializeObject<dynamic>(await DataDragonUtils.GetAsync($"{version.CDN}/{version.Item}/data/en_US/item.json")).data.ToObject<Dictionary<int, ItemData>>());
+            List<KeyValuePair<int, ItemData>> rawItemData = new List<KeyValuePair<int, ItemData>>(JsonConvert.DeserializeObject<dynamic>(await DataDragonUtils.GetAsync($"{version.CDN}/{version.Item}/data/{ConfigController.Component.DataDragon.lang}/item.json")).data.ToObject<Dictionary<int, ItemData>>());
             Log.Info($"Detected {rawItemData.Count} items");
 
             rawItemData.ForEach(kvPair => {


### PR DESCRIPTION
Hey,

I wanna help in dev and i found a solution for #34 issue. Items name be taken from ddragon, so it's our decision what language it's will have. I test it and it's neccesary for display item indicator in selected language. Only what to do is add dropdown in settings page with language selection.
( https://ddragon.leagueoflegends.com/cdn/languages.json ) and save it to Component.json (lang)

Example:
http://ddragon.leagueoflegends.com/cdn/11.14.1/data/en_US/item.json
http://ddragon.leagueoflegends.com/cdn/11.14.1/data/pl_PL/item.json
http://ddragon.leagueoflegends.com/cdn/11.14.1/data/es_ES/item.json
etc
<img width="1805" alt="itemlang" src="https://user-images.githubusercontent.com/47286873/125467015-4cfdaf33-64c5-457a-b698-792211e94acd.png">

Cheers