### PR TITLE
Fix older FileVersions just in case

### DIFF
--- a/Offsets/Offsets-13.10.1.json
+++ b/Offsets/Offsets-13.10.1.json
@@ -25,5 +25,5 @@
     "Name": "0x38D0",
     "NameLength": "0x38E0"
   },
-  "FileVersion": "2.0"
+  "FileVersion": "3.0"
 }

--- a/Offsets/Offsets-13.11.1.json
+++ b/Offsets/Offsets-13.11.1.json
@@ -25,5 +25,5 @@
     "Name": "0x38c8",
     "NameLength": "0x38d8"
   },
-  "FileVersion": "1.0"
+  "FileVersion": "3.0"
 }

--- a/Offsets/Offsets-13.11.2.json
+++ b/Offsets/Offsets-13.11.2.json
@@ -25,5 +25,5 @@
     "Name": "0x38c8",
     "NameLength": "0x38d8"
   },
-  "FileVersion": "1.0"
+  "FileVersion": "3.0"
 }

--- a/Offsets/Offsets-13.12.1.json
+++ b/Offsets/Offsets-13.12.1.json
@@ -25,5 +25,5 @@
     "Name": "0x3850",
     "NameLength": "0x3860"
   },
-  "FileVersion": "1.0"
+  "FileVersion": "3.0"
 }

--- a/Offsets/Offsets-13.9.1.json
+++ b/Offsets/Offsets-13.9.1.json
@@ -25,5 +25,5 @@
     "Name": "0x3898",
     "NameLength": "0x38A8"
   },
-  "FileVersion": "1.0"
+  "FileVersion": "3.0"
 }


### PR DESCRIPTION
All offset files after patch Offsets-13.7.1.json should have "FileVersion": "3.0"
