### PR TITLE
Quick Fix #301 / Improve OnDamageGiven handling

### DIFF
--- a/LeagueBroadcast/Ingame/Data/Provider/LiveEventsDataProvider.cs
+++ b/LeagueBroadcast/Ingame/Data/Provider/LiveEventsDataProvider.cs
@@ -233,9 +233,7 @@ namespace LeagueBroadcast.Ingame.Data.Provider
                         OnPlateDestroy(e);
                         break;
                     case ("OnDamageGiven"):
-                        // commented out due to crashes when handling damage events related to turrets
-                        // see issue #301
-                        //OnDamageDealt(e);
+                        OnDamageDealt(e);
                         break;
                     default:
                         break;
@@ -270,12 +268,13 @@ namespace LeagueBroadcast.Ingame.Data.Provider
             if (p is not null && e.Other is not null && e.Other.StartsWith("Turret", StringComparison.OrdinalIgnoreCase))
             {
                 //player damage turret
-                Turret turret = Ingame.gameState.turrets[e.Other];
-                if (turret is null)
+                bool found = Ingame.gameState.turrets.TryGetValue(e.Other, out Turret turret);
+                if (!found)
                 {
                     Log.Verbose("Tried adding damage info to unknown turret: " + e.Other);
                     return;
                 }
+                Turret turret = Ingame.gameState.turrets[e.Other];
                 turret.LastDamagedByDictionary[p] = Ingame.gameData.gameTime;
             }
 

--- a/LeagueBroadcast/Ingame/Data/Provider/LiveEventsDataProvider.cs
+++ b/LeagueBroadcast/Ingame/Data/Provider/LiveEventsDataProvider.cs
@@ -233,7 +233,9 @@ namespace LeagueBroadcast.Ingame.Data.Provider
                         OnPlateDestroy(e);
                         break;
                     case ("OnDamageGiven"):
-                        OnDamageDealt(e);
+                        // commented out due to crashes when handling damage events related to turrets
+                        // see issue #301
+                        //OnDamageDealt(e);
                         break;
                     default:
                         break;


### PR DESCRIPTION
This should be the easiest/least painful temporary fix for the crashes related to turret damage seen in #301.
Removing the handling of OnDamageGiven events for now shouldn't be a big deal as this part of the code is still WIP as far as I can tell.

@floh22 Needs your review/approval, I will leave merging/releasing a new version to you since I have no idea about the build setup.